### PR TITLE
 #170142313 updating comment endpoint to database

### DIFF
--- a/server/v2/controlers/recordController.js
+++ b/server/v2/controlers/recordController.js
@@ -90,6 +90,38 @@ class recordController {
       message: "Record not found"
     });
   }
+
+  static async updateRedflagcomment(req, res) {
+    const id = parseInt(req.params.redflagid, 10);
+    const flag = await executeQuerry(queries[1].getRecord, [id]);
+    const userId = req.userId;
+
+    if (flag.length === 1) {
+      if (flag[0].createdby == userId) {
+        const { comment } = req.body;
+        const flag2 = await executeQuerry(queries[1].editRecordComment, [
+          comment,
+          id
+        ]);
+        return res.status(200).json({
+          status: 200,
+          message: "Updated red-flag record’s comment",
+          data: {
+            id: flag2[0].id,
+            location: flag2[0].comment
+          }
+        });
+      }
+      return res.status(400).json({
+        status: 401,
+        message: "you cannot edit a record that you did not create"
+      });
+    }
+    return res.status(404).json({
+      status: 404,
+      message: "Record not found"
+    });
+  }
 }
 
 export default recordController;

--- a/server/v2/routes/recordRouter.js
+++ b/server/v2/routes/recordRouter.js
@@ -19,11 +19,11 @@ router.patch(
   recordController.updateRedflaglocation
 );
 
-// router.patch(
-//   "/:redflagid/comment",
-//   tokenVerify,
-//   recordController.updateRedflagcomment
-// );
+router.patch(
+  "/:redflagid/comment",
+  tokenVerify,
+  recordController.updateRedflagcomment
+);
 
 router.get("/:redflagid", recordController.getSingleRedflag);
 

--- a/server/v2/test/records.test.js
+++ b/server/v2/test/records.test.js
@@ -172,4 +172,48 @@ describe(" record tests", () => {
         done();
       });
   });
+
+  it("user should be able to edit the comment of a record they created", done => {
+    chai
+      .request(app)
+      .patch("/api/v2/red-flags/1/comment")
+      .set("token", tok)
+      .send({ comment: "it has been long" })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.property(
+          "message",
+          "Updated red-flag record’s comment"
+        );
+        res.body.should.be.an("object");
+        done();
+      });
+  });
+
+  it("user should not be able to edit the comment of a record they did not create", done => {
+    chai
+      .request(app)
+      .patch("/api/v2/red-flags/1/comment")
+      .set("token", tok2)
+      .send({ comment: "dsfasdfa" })
+      .end((err, res) => {
+        res.should.have.status(401);
+        res.body.should.be.an("object");
+        done();
+      });
+  });
+
+  it("user should not be able to edit the comment of a record that does not exist", done => {
+    chai
+      .request(app)
+      .patch("/api/v2/red-flags/2/comment")
+      .set("token", tok)
+      .send({ comment: "dsfasdfa" })
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.have.property("message", "Record not found");
+        res.body.should.be.an("object");
+        done();
+      });
+  });
 });


### PR DESCRIPTION
### what does this PR do?
- Allows a user to connect to the database, by allowing a user to update the comment record they created 

### Description of the task to be completed?

- Create an endpoint that enables a user to edit the comment of the record
- write tests for this functionality
### How should this be manually tested?
- clone the repository `git clone https://github.com/karengir/Broadcaster.git and cd into the directory Broadcaster`
-checkout to the branch ` ft-edit-commentendpoint-database-170142313`
Run command npm run dev
- using postman,
Navigate to ` http://localhost:5000/api/v2/red-flags/21/comment` to create a record,
- send request

### What are the relevant pivotal tracker stories?
[#170142313](https://www.pivotaltracker.com/story/show/170142313)
### screenshot
![updateComment](https://user-images.githubusercontent.com/53523700/70284155-c3437780-17cb-11ea-820e-443e3f9fe0c7.PNG)
